### PR TITLE
Accept /usr/local/lib as a potential location for libmgba.so.0.9.0

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -1,7 +1,23 @@
+use std::path;
+
+fn find_mgba_library() -> Option<&'static str> {
+    const POTENTIAL_LIBRARY_LOCATIONS: &[&str] = &[
+        "/usr/lib/libmgba.so.0.9.0",
+        "/usr/local/lib/libmgba.so.0.9.0",
+    ];
+
+    POTENTIAL_LIBRARY_LOCATIONS
+        .iter()
+        .find(|file_path| path::Path::new(file_path).exists())
+        .copied()
+}
+
 fn main() {
+    let mgba_library = find_mgba_library().expect("Need mgba 0.9.0 installed");
+
     cc::Build::new()
         .file("c/test-runner.c")
-        .object("/usr/lib/libmgba.so.0.9.0")
+        .object(mgba_library)
         .include("c/include")
         .compile("test-runner");
 }


### PR DESCRIPTION
This is where it installs by default if you build it from source :).